### PR TITLE
詳細画面に工数表示

### DIFF
--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -935,7 +935,13 @@ input[name="project[member_flag]"] {
       max-width: 400px;
     }
   }
-  .project_member{
+  .project_remark{
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+  .project_member,.project_hour{
+    width: 48%;
     dt{
       background-image: linear-gradient(to bottom, #ddd, #ddd);
       background-repeat: no-repeat;
@@ -977,6 +983,32 @@ input[name="project[member_flag]"] {
       }
     }
   }
+
+  .project_hour{
+    dt{
+      margin-bottom: 8px;
+    }
+    dd{
+      margin-top: 6px;
+      align-items: baseline;
+      h5{
+        padding: 0 8px 0 0;
+        margin-right: 4px;
+        font-size: 1.4rem;
+        // font-weight: bold;
+      }
+      p{
+        font-size: 2.4rem;
+        border-bottom: 1.5px solid #1d945d;
+        small{
+          font-size: 72%;
+          color: #333;
+        }
+      }
+    }
+  }
+
+
   .comment_box{
     margin-top: 28px;
     padding-top: 12px;

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -34,6 +34,24 @@ class ProjectsController < ApplicationController
   def show
     @comments = @project.comments.includes(:user).order(id: :desc)
     @comment = Comment.new
+    designer = @project.schedules.includes(:shares).where(work_id: '3')
+    engineer = @project.schedules.includes(:shares).where(work_id: '4')
+
+    @share_designer = 0
+    designer.each do |d|
+      d.shares.each do |share|
+        @share_designer += share.hour.name.to_f
+      end
+    end
+
+    @share_engineer = 0
+    engineer.each do |e|
+      e.shares.each do |share|
+        @share_engineer += share.hour.name.to_f
+      end
+    end
+
+    @sum = (@share_designer + @share_engineer) * 0.15
   end
 
   def edit

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -25,7 +25,7 @@
       <p><span>FIX予定日</span><%= @project.project_end %></p>
       <div class="project_author">
         <p>最終更新日：<%= @project.updated_at.strftime('%Y/%m/%d %H:%M:%S') %></p>
-        <% @project.users.last(1).each do |member| %>
+        <% @project.users.first(1).each do |member| %>
           <p>作成者：<%= member.nickname %></p>
         <% end %>
       </div>
@@ -35,9 +35,11 @@
         <% end %>
       <% end %>
     </div>
+
     <div class="project_about">
       <p><%= safe_join(@project.about.split("\n"),tag(:br)) %><p>
     </div>
+
     <ul class="project_file">
     <% @project.files.each do |file| %>
       <% if file.representable? %>
@@ -53,7 +55,9 @@
       <% end %>
     <% end %>
     </ul>
-    <dl class="project_member">
+
+    <div class="project_remark">
+      <dl class="project_member">
       <dt><span>プロジェクトメンバー</span></dt>
       <% @project.users.each do |member| %>
       <dd>
@@ -62,6 +66,26 @@
       </dd>
       <% end %>
     </dl>
+    <dl class="project_hour">
+      <dt><span>プロジェクト工数</span></dt>
+      <dd>
+        <h5>合計</h5>
+        <p class="f-en"><%= @share_designer + @share_engineer + @sum %><small>day</small></p>
+      </dd>
+      <dd>
+        <h5>デザイナー工数</h5>
+        <p class="f-en"><%= @share_designer %><small>day</small></p>
+      </dd>
+      <dd>
+        <h5>エンジニア工数</h5>
+        <p class="f-en"><%= @share_engineer %><small>day</small></p>
+      </dd>
+      <dd>
+        <h5>進捗管理(15%)</h5>
+        <p class="f-en"><%= @sum %><small>day</small></p>
+      </dd>
+    </dl>
+    </div>
 
     <section class="comment_box">
       <h3>コメント欄</h3>


### PR DESCRIPTION
# What
スケジュール詳細画面で設定した実工数のデータをプロジェクト一覧にて、工数として表示する

# Why
- デザイナーとエンジニアの実工数の数字を表示し、2つの合計×15%を進捗管理とする
- デザイナー工数、エンジニア工数、進捗管理工数の合計をプロジェクト全体の工数とする
- 提案費などディレクションに関わる費用は別途計算するものとする（打合せの時間は見積りに反映させないため）